### PR TITLE
支持程序维度设置代理

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,5 @@
+package proxy
+
+import "net/http"
+
+var Proxy = http.ProxyFromEnvironment

--- a/openapi/v1/openapi.go
+++ b/openapi/v1/openapi.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2" // resty 是一个优秀的 rest api 客户端，可以极大的减少开发基于 rest 标准接口求请求的封装工作量
+
 	"github.com/2mf8/Go-QQ-Client/errs"
+	"github.com/2mf8/Go-QQ-Client/internal/proxy"
 	"github.com/2mf8/Go-QQ-Client/log"
 	"github.com/2mf8/Go-QQ-Client/openapi"
 	"github.com/2mf8/Go-QQ-Client/token"
@@ -134,7 +136,7 @@ func createTransport(localAddr net.Addr, idleConns int) *http.Transport {
 		dialer.LocalAddr = localAddr
 	}
 	return &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
+		Proxy:                 proxy.Proxy,
 		DialContext:           dialer.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          idleConns,

--- a/register.go
+++ b/register.go
@@ -1,6 +1,10 @@
 package bot
 
 import (
+	"net/http"
+	"net/url"
+
+	"github.com/2mf8/Go-QQ-Client/internal/proxy"
 	"github.com/2mf8/Go-QQ-Client/log"
 	"github.com/2mf8/Go-QQ-Client/openapi"
 	"github.com/2mf8/Go-QQ-Client/websocket"
@@ -24,4 +28,13 @@ func SetWebsocketClient(c websocket.WebSocket) {
 // SetOpenAPIClient 注册 openapi 的不同实现，需要设置版本
 func SetOpenAPIClient(v openapi.APIVersion, c openapi.OpenAPI) {
 	openapi.Register(v, c)
+}
+
+// SetProxy 设置代理
+//
+// 若调用了SetWebsocketClient，会导致websocket代理无效，请自行设置websocket代理
+//
+// 若无设置，则使用系统代理
+func SetProxy(p func(*http.Request) (*url.URL, error)) {
+	proxy.Proxy = p
 }


### PR DESCRIPTION
原先默认使用的系统代理，但在有时候代理只希望设置在程序维度，不影响其他系统功能，故在register中新增SetProxy函数，websocket和http都使用该函数设置的代理，并保持默认使用系统代理的逻辑不变